### PR TITLE
Addresses https://github.com/postgis/postgis-java/issues/27 [java2d point parsing]

### DIFF
--- a/postgis-jdbc-java2d/src/main/java/org/postgis/java2d/PGShapeGeometry.java
+++ b/postgis-jdbc-java2d/src/main/java/org/postgis/java2d/PGShapeGeometry.java
@@ -39,16 +39,11 @@ import org.postgresql.util.PGobject;
  * 
  * As the java.awt.Shape methods currently are implemented by using a
  * java.awt.geom.GeneralPath object, they have the same semantics.
- * 
- * BUG/TODO: MultiPoints or Points in a Geometry Collection currently don't work
- * as expected, as some GeneralPath implementations throw away adjacent MoveTo
- * commands as an optimization (e. G. sun 1.5 and ibm 1.5). Points thus are
- * translated into MoveTo() followed by a closePath. This may change when we
- * implement our own path logics. We have to evaluate whether Graphics2D renders
- * a single MoveTo command as a single "brush tip", or we need the closePath()
- * command nevertheless to get any drawing. Maybe we need a LineTo() to the same
- * coordinages instead.
- * 
+ *
+ * NOTE: (Multi)Points are translated into a sequence of single MoveTo and LineTo
+ * commands, but WITHOUT a closePath command.  When rendering with a stroke that
+ * is not solid, the points may not be rendered.
+ *
  * (Multi)LineStrings are translated into a sequence of a single MoveTo and
  * multiple LineTo vertices, and Polygon rings into a sequence of a single
  * MoveTo, multiple LineTo and a closePath command. To allow correct Polygon

--- a/postgis-jdbc-java2d/src/main/java/org/postgis/java2d/ShapeBinaryParser.java
+++ b/postgis-jdbc-java2d/src/main/java/org/postgis/java2d/ShapeBinaryParser.java
@@ -154,8 +154,10 @@ public class ShapeBinaryParser {
     }
 
     private void parsePoint(ValueGetter data, boolean haveZ, boolean haveM, GeneralPath path) {
-        path.moveTo((float) data.getDouble(), (float) data.getDouble());
-        path.closePath();
+        double x = data.getDouble();
+        double y = data.getDouble();
+        path.moveTo(x, y);
+        path.lineTo(x, y);
         skipZM(data, haveZ, haveM);
     }
 


### PR DESCRIPTION
- Modifications to ShapeBinaryParser to use a LINETO command instead of a CLOSEPATH command when a point is parsed.
- Updated the note in PGShapeGeometry to more accurately describe the gotcha when rendering points
- Fixed TestJava2d to properly render geometries even when they have negative coordinate values.