### PR TITLE
Update PostgreSQL version and group.

### DIFF
--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -25,9 +25,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>postgresql</groupId>
+            <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>[9.1-901.jdbc3,)</version>
+            <version>[9.4.1208.jre7,)</version>
         </dependency>
     </dependencies>
 

--- a/jdbc/src/main/java/org/postgis/DriverWrapper.java
+++ b/jdbc/src/main/java/org/postgis/DriverWrapper.java
@@ -179,10 +179,8 @@ public class DriverWrapper extends Driver {
      * @see java.sql.Driver#acceptsURL
      * @param url the URL of the driver
      * @return true if this driver accepts the given URL
-     * @exception SQLException Passed through from the underlying PostgreSQL
-     *                driver, should not happen.
      */
-    public boolean acceptsURL(String url) throws SQLException {
+    public boolean acceptsURL(String url) {
         try {
             url = mangleURL(url);
         } catch (SQLException e) {

--- a/jdbc_jtsparser/src/main/java/org/postgis/jts/JtsGisWrapper.java
+++ b/jdbc_jtsparser/src/main/java/org/postgis/jts/JtsGisWrapper.java
@@ -120,10 +120,8 @@ public class JtsGisWrapper extends Driver {
      * @see java.sql.Driver#acceptsURL
      * @param url the URL of the driver
      * @return true if this driver accepts the given URL
-     * @exception SQLException if a database-access error occurs (Dont know why
-     *                it would *shrug*)
      */
-    public boolean acceptsURL(String url) throws SQLException {
+    public boolean acceptsURL(String url) {
         try {
             url = mangleURL(url);
         } catch (SQLException e) {

--- a/jdbc_jtsparser/src/main/java/org/postgis/jts/JtsWrapper.java
+++ b/jdbc_jtsparser/src/main/java/org/postgis/jts/JtsWrapper.java
@@ -126,10 +126,8 @@ public class JtsWrapper extends Driver {
      * @see java.sql.Driver#acceptsURL
      * @param url the URL of the driver
      * @return true if this driver accepts the given URL
-     * @exception SQLException Passed through from the underlying PostgreSQL
-     *                driver, should not happen.
      */
-    public boolean acceptsURL(String url) throws SQLException {
+    public boolean acceptsURL(String url) {
         try {
             url = mangleURL(url);
         } catch (SQLException e) {

--- a/postgis-jdbc-java2d/src/main/java/org/postgis/java2d/Java2DWrapper.java
+++ b/postgis-jdbc-java2d/src/main/java/org/postgis/java2d/Java2DWrapper.java
@@ -127,10 +127,8 @@ public class Java2DWrapper extends Driver {
      * @see java.sql.Driver#acceptsURL
      * @param url the URL of the driver
      * @return true if this driver accepts the given URL
-     * @exception SQLException if a database-access error occurs (Dont know why
-     *                it would *shrug*)
      */
-    public boolean acceptsURL(String url) throws SQLException {
+    public boolean acceptsURL(String url) {
         try {
             url = mangleURL(url);
         } catch (SQLException e) {


### PR DESCRIPTION
According to http://mvnrepository.com/artifact/postgresql/postgresql the artifact has been moved from group `postgresql` to `org.postgresql`.
Unfortunately using the old version in PostGIS JDBC and declaring a newer version in a project using it will result in the inclusion of two PostgreSQL JDBC with different versions in the resulting application.

I had to change the `acceptsURL` functions of the `DriverWrapper`s as well to not declare throwing a `SQLException` as `org.postgresql.Driver.acceptsURL` does no more throw it.