### PR TITLE
PostGIS JDBC driver should not depend on a specific logging framework.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,16 +136,19 @@
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <version>${dependency.logback.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
             <version>${dependency.logback.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>${dependency.slfj.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testng</groupId>


### PR DESCRIPTION
Currently using the PostGIS JDBC driver draws in slf4j and logback dependencies. The driver itself only uses `java.util.logging` classes except for tests.
Therefore change the dependencies to test scope.