### PR TITLE
org.postgresql 42.2.2 doesn't thow exception any more.

### DIFF
--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>9.4.1208.jre7</version>
+            <version>42.2.2.jre7</version>
         </dependency>
     </dependencies>
 

--- a/jdbc/src/main/java/org/postgis/DriverWrapper.java
+++ b/jdbc/src/main/java/org/postgis/DriverWrapper.java
@@ -339,7 +339,7 @@ public class DriverWrapper extends Driver {
         }
     }
 
-    public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+    public Logger getParentLogger() {
         throw new UnsupportedOperationException("Not supported yet.");
     }
 }


### PR DESCRIPTION
The `postgis-java` package failed to build in Debian after `libpostgresql-jdbc-java` was updated to 42.2.2 because the `getParentLogger()` method no longer throws an exception.