### PR TITLE
updates postgresql jdbc driver version and addresses driver class wrapper changes

### DIFF
--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.2.2.jre7</version>
+            <version>${dependency.postgresql-jdbc.version}</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -78,8 +78,8 @@
         <url>https://github.com/postgis/postgis-java</url>
         <connection>scm:git:git://github.com/postgis/postgis-java.git</connection>
         <developerConnection>scm:git:git@github.com:postgis/postgis-java.git</developerConnection>
-      <tag>HEAD</tag>
-  </scm>
+        <tag>HEAD</tag>
+    </scm>
     <issueManagement>
         <system>GitHub Issues</system>
         <url>https://github.com/postgis/postgis-java/issues</url>
@@ -135,6 +135,7 @@
         <maven-war-plugin.version>3.2.0</maven-war-plugin.version>
         <!-- Dependency versions -->
         <dependency.logback.version>1.2.3</dependency.logback.version>
+        <dependency.postgresql-jdbc.version>42.2.5.jre7</dependency.postgresql-jdbc.version>
         <dependency.slfj.version>1.7.25</dependency.slfj.version>
         <dependency.testng.version>6.14.3</dependency.testng.version>
     </properties>

--- a/postgis-jdbc-java2d/src/main/java/org/postgis/java2d/Java2DWrapper.java
+++ b/postgis-jdbc-java2d/src/main/java/org/postgis/java2d/Java2DWrapper.java
@@ -165,7 +165,7 @@ public class Java2DWrapper extends Driver {
         return "Java2DWrapper " + REVISION + ", wrapping " + Driver.getVersion();
     }
 
-    public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+    public Logger getParentLogger() {
         throw new UnsupportedOperationException("Not supported yet.");
     }
 }


### PR DESCRIPTION
- Created property which specifies the postgresql jdbc driver version
- Update postgresql jdbc driver from v42.2.2.jre7 to v42.2.5.jre7
- Updated getParentLogger method signature in Java2DWrapper class to remove the
  "throws SQLFeatureNotSupportedException" clause which apparently not longer
  exists in newer postgresql jdbc drivers