### PR TITLE
Dependency Updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
         <test.db.name>postgis1</test.db.name>
         <test.db.port>5432</test.db.port>
         <!-- Plugin versioning -->
-        <build-helper-maven-plugin.version>3.0.0</build-helper-maven-plugin.version>
+        <build-helper-maven-plugin.version>3.1.0</build-helper-maven-plugin.version>
         <directory-maven-plugin.version>0.3.1</directory-maven-plugin.version>
         <download-maven-plugin.version>1.5.0</download-maven-plugin.version>
         <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
@@ -124,7 +124,7 @@
         <maven-checkstyle-plugin.version>3.1.1</maven-checkstyle-plugin.version>
         <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
-        <maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
+        <maven-dependency-plugin.version>3.1.2</maven-dependency-plugin.version>
         <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
         <maven-ear-plugin.version>3.0.2</maven-ear-plugin.version>
         <maven-ejb-plugin.version>3.0.1</maven-ejb-plugin.version>
@@ -134,21 +134,21 @@
         <maven-install-plugin.version>2.5.2</maven-install-plugin.version>
         <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
         <maven-jarsigner-plugin.version>3.0.0</maven-jarsigner-plugin.version>
-        <maven-javadoc-plugin.version>3.1.1</maven-javadoc-plugin.version>
+        <maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
         <maven-jxr-plugin.version>3.0.0</maven-jxr-plugin.version>
         <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
         <maven-resources-plugin.version>3.1.0</maven-resources-plugin.version>
-        <maven-site-plugin.version>3.8.2</maven-site-plugin.version>
+        <maven-site-plugin.version>3.9.0</maven-site-plugin.version>
         <maven-shade-plugin.version>3.2.2</maven-shade-plugin.version>
         <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
         <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
         <maven-war-plugin.version>3.2.3</maven-war-plugin.version>
         <versions-maven-plugin.version>2.7</versions-maven-plugin.version>
         <!-- Dependency versions -->
-        <dependency.checkstyle.version>8.30</dependency.checkstyle.version>
+        <dependency.checkstyle.version>8.31</dependency.checkstyle.version>
         <dependency.jts-version.version>1.16.1</dependency.jts-version.version>
         <dependency.logback.version>1.2.3</dependency.logback.version>
-        <dependency.postgresql-jdbc.version>42.2.10</dependency.postgresql-jdbc.version>
+        <dependency.postgresql-jdbc.version>42.2.11</dependency.postgresql-jdbc.version>
         <dependency.slfj.version>1.7.30</dependency.slfj.version>
         <dependency.spatial4j.version>0.7</dependency.spatial4j.version>
         <dependency.testcontainers.version>1.13.0</dependency.testcontainers.version>

--- a/tools/osgeo-postgis-jdbc-test-util/pom.xml
+++ b/tools/osgeo-postgis-jdbc-test-util/pom.xml
@@ -39,11 +39,6 @@
             <version>${dependency.logback.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>${dependency.slfj.version}</version>
-        </dependency>
-        <dependency>
             <groupId>net.postgis.tools</groupId>
             <artifactId>test-utils</artifactId>
             <version>2.4.1-SNAPSHOT</version>


### PR DESCRIPTION
- build-helper-maven-plugin updated from v3.0.0 to v3.1.0
- maven-dependency-plugin updates from v3.1.1 to v3.1.2
- maven-javadoc-plugin updated from v3.1.1 to v3.2.0
- maven-site-plugin updated from v3.8.2 to v3.9.0
- checkstyle updated from v8.30 to 8.31
- postgresql-jdbc updated from v42.2.10 to v42.2.11
- Removed redundant slf4j dependency declaration in osgeo-postgis-jdbc-test-util module