### PR TITLE
Update JTS to 1.18.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
         <versions-maven-plugin.version>2.7</versions-maven-plugin.version>
         <!-- Dependency versions -->
         <dependency.checkstyle.version>8.31</dependency.checkstyle.version>
-        <dependency.jts-version.version>1.16.1</dependency.jts-version.version>
+        <dependency.jts-version.version>1.18.1</dependency.jts-version.version>
         <dependency.logback.version>1.2.3</dependency.logback.version>
         <dependency.postgresql-jdbc.version>42.2.11</dependency.postgresql-jdbc.version>
         <dependency.slfj.version>1.7.30</dependency.slfj.version>


### PR DESCRIPTION
There was a binary-incompatible change in version [1.17.0](https://github.com/locationtech/jts/releases/tag/1.17.0); I think it would make sense to update this now before the new major version of PostGIS ships, instead of within a major version.