### PR TITLE
Updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
         <jxr.skip>false</jxr.skip>
         <pmd.skip>true</pmd.skip>
         <spotbugs.skip>true</spotbugs.skip>
-        <test.container.image>postgis/postgis:14-3.2-alpine</test.container.image>
+        <test.container.image>postgis/postgis:15-3.3-alpine</test.container.image>
         <test.db.username>postgis1</test.db.username>
         <test.db.password>postgis1</test.db.password>
         <test.db.name>postgis1</test.db.name>
@@ -118,50 +118,50 @@
         <build-helper-maven-plugin.version>3.3.0</build-helper-maven-plugin.version>
         <directory-maven-plugin.version>1.0</directory-maven-plugin.version>
         <download-maven-plugin.version>1.6.8</download-maven-plugin.version>
-        <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
+        <exec-maven-plugin.version>3.1.0</exec-maven-plugin.version>
         <git-commit-id-plugin.version>4.9.10</git-commit-id-plugin.version>
-        <jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
-        <maven-antrun-plugin.version>3.0.0</maven-antrun-plugin.version>
+        <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
+        <maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
         <maven-archetype-plugin.version>3.2.1</maven-archetype-plugin.version>
-        <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
-        <maven-checkstyle-plugin.version>3.1.2</maven-checkstyle-plugin.version>
-        <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
-        <maven-compiler-plugin.version>3.9.0</maven-compiler-plugin.version>
-        <maven-dependency-plugin.version>3.2.0</maven-dependency-plugin.version>
-        <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
-        <maven-ear-plugin.version>3.2.0</maven-ear-plugin.version>
+        <maven-assembly-plugin.version>3.4.2</maven-assembly-plugin.version>
+        <maven-checkstyle-plugin.version>3.2.0</maven-checkstyle-plugin.version>
+        <maven-clean-plugin.version>3.2.0</maven-clean-plugin.version>
+        <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
+        <maven-dependency-plugin.version>3.4.0</maven-dependency-plugin.version>
+        <maven-deploy-plugin.version>3.0.0</maven-deploy-plugin.version>
+        <maven-ear-plugin.version>3.3.0</maven-ear-plugin.version>
         <maven-ejb-plugin.version>3.0.1</maven-ejb-plugin.version>
-        <maven-enforcer-plugin.version>3.0.0</maven-enforcer-plugin.version>
+        <maven-enforcer-plugin.version>3.1.0</maven-enforcer-plugin.version>
         <maven-failsafe-plugin.version>2.22.2</maven-failsafe-plugin.version>
         <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
-        <maven-install-plugin.version>2.5.2</maven-install-plugin.version>
-        <maven-jar-plugin.version>3.2.2</maven-jar-plugin.version>
+        <maven-install-plugin.version>3.1.0</maven-install-plugin.version>
+        <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
         <maven-jarsigner-plugin.version>3.0.0</maven-jarsigner-plugin.version>
-        <maven-javadoc-plugin.version>3.3.1</maven-javadoc-plugin.version>
-        <maven-jxr-plugin.version>3.1.1</maven-jxr-plugin.version>
-        <maven-pmd-plugin.version>3.15.0</maven-pmd-plugin.version>
-        <maven-project-info-reports-plugin.version>3.1.2</maven-project-info-reports-plugin.version>
+        <maven-javadoc-plugin.version>3.4.1</maven-javadoc-plugin.version>
+        <maven-jxr-plugin.version>3.3.0</maven-jxr-plugin.version>
+        <maven-pmd-plugin.version>3.19.0</maven-pmd-plugin.version>
+        <maven-project-info-reports-plugin.version>3.4.1</maven-project-info-reports-plugin.version>
         <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
-        <maven-resources-plugin.version>3.2.0</maven-resources-plugin.version>
-        <maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>
-        <maven-site-plugin.version>3.10.0</maven-site-plugin.version>
+        <maven-resources-plugin.version>3.3.0</maven-resources-plugin.version>
+        <maven-shade-plugin.version>3.4.1</maven-shade-plugin.version>
+        <maven-site-plugin.version>3.12.1</maven-site-plugin.version>
         <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
         <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
         <maven-surefire-report-plugin.version>2.22.2</maven-surefire-report-plugin.version>
         <maven-war-plugin.version>3.3.2</maven-war-plugin.version>
-        <spotbugs-maven-plugin.version>4.5.3.0</spotbugs-maven-plugin.version>
-        <versions-maven-plugin.version>2.9.0</versions-maven-plugin.version>
+        <spotbugs-maven-plugin.version>4.7.3.0</spotbugs-maven-plugin.version>
+        <versions-maven-plugin.version>2.14.1</versions-maven-plugin.version>
         <!-- Dependency versions -->
-        <dependency.checkstyle.version>9.2.1</dependency.checkstyle.version>
+        <dependency.checkstyle.version>9.3</dependency.checkstyle.version>
         <dependency.jts-version.version>1.18.2</dependency.jts-version.version>
-        <dependency.logback.version>1.2.10</dependency.logback.version>
-        <dependency.pmd.version>6.41.0</dependency.pmd.version>
-        <dependency.postgresql-jdbc.version>42.3.1</dependency.postgresql-jdbc.version>
-        <dependency.slf4j.version>1.7.35</dependency.slf4j.version>
+        <dependency.logback.version>1.3.5</dependency.logback.version>
+        <dependency.pmd.version>6.52.0</dependency.pmd.version>
+        <dependency.postgresql-jdbc.version>42.5.1</dependency.postgresql-jdbc.version>
+        <dependency.slf4j.version>2.0.6</dependency.slf4j.version>
         <dependency.spatial4j.version>0.8</dependency.spatial4j.version>
-        <dependency.spotbugs.version>4.5.3</dependency.spotbugs.version>
-         <dependency.testcontainers.version>1.16.3</dependency.testcontainers.version>
-        <dependency.testng.version>6.14.3</dependency.testng.version>
+        <dependency.spotbugs.version>4.7.3</dependency.spotbugs.version>
+        <dependency.testcontainers.version>1.17.6</dependency.testcontainers.version>
+        <dependency.testng.version>7.5</dependency.testng.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
- exec-maven-plugin updated from v3.0.0 to v3.1.0
- jacoco-maven-plugin updated from v0.8.7 to v0.8.8
- maven-antrun-plugin updated from v3.0.0 to v3.1.0
- maven-assembly-plugin updated from v3.3.0 to 3.4.2
- maven-checkstyle-plugin updated from v3.1.2 to v3.2.0
- maven-clean-plugin updated from v3.1.0 to v3.2.0
- maven-compiler-plugin updated from v3.9.0 to v3.10.1
- maven-dependency-plugin updated from v3.2.0 to v3.4.0
- maven-deploy-plugin updated from v2.8.2 to v3.0.0
- maven-ear-plugin updated from v3.2.0 to v3.3.0
- maven-enforcer-plugin updated from v3.0.0 to 3.1.0
- maven-install-plugin updated from v2.5.2 to v3.1.0
- maven-jar-plugin updated from v3.2.2 to v3.3.0
- maven-javadoc-plugin updated from v3.3.1 to v3.4.1
- maven-jxr-plugin updated from v3.1.1 to v3.3.0
- maven-pmd-plugin updated from v3.15.0 to v3.19.0
- maven-project-info-reports-plugin updated from v3.1.2 to v3.4.1
- maven-resources-plugin updated from v3.2.0 to v3.3.0
- maven-shade-plugin updated from v3.2.4 to v3.4.1
- maven-site-plugin updated from v3.10.0 to v3.12.1
- spotbugs-maven-plugin updated from v4.5.3.0 to v4.7.3.0
- versions-maven-plugin updated from v2.9.0 to v2.14.1
- checkstyle updated from v9.2.1 to v9.3
- logback updated from v1.2.10 to v1.3.5
- pmd updated from v6.41.0 to v6.52.0
- postgresql-jdbc updated from v42.3.1 to v42.5.1
- slf4j updated from v1.7.35 to v2.0.6
- spotbugs updated from v4.5.3 to v4.7.3
- testcontainers updated from v1.16.4 to v1.17.6
- testng updated from v6.14.3 to v7.5

Signed-off-by: Phillip Ross <phillip.w.g.ross@gmail.com>