### PR TITLE
Build updates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,19 +10,19 @@ jobs:
   build-codebase:
     strategy:
       matrix:
-        os: [ubuntu-22.04]
-        jdk_version: [8.0.392-zulu, 11.0.21-zulu, 17.0.9-zulu, 21.0.1-zulu]
-        maven_version: [3.9.6]
+        os: [ubuntu-24.04]
+        jdk_version: [8.0.422-zulu, 11.0.24-zulu, 17.0.12-zulu, 21.0.4-zulu]
+        maven_version: [3.9.8]
         include:
-          - os: ubuntu-22.04
-            jdk_version: 8.0.392-zulu
-            zulu_version: 8.74.0.17
-            maven_version: 3.9.6
+          - os: ubuntu-24.04
+            jdk_version: 8.0.422-zulu
+            zulu_version: 8.80.0.17
+            maven_version: 3.9.8
             maven_deploy: true
             docker_build: true
             maven_docker_container_image_repo: luminositylabs
             maven_docker_container_image_name: maven
-            maven_docker_container_image_tag: 3.9.6_openjdk-8u392_zulu-8.74.0.17
+            maven_docker_container_image_tag: 3.9.8_openjdk-8u422_zulu-alpine-8.80.0.17
     name: Build on OS ${{ matrix.os }} with Maven ${{ matrix.maven_version }} using JDK ${{ matrix.jdk_version }}
     runs-on: ${{ matrix.os }}
     env:
@@ -32,7 +32,7 @@ jobs:
 
     steps:
     - name: Checkout Source
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Install GPG and generate test key
       run: .github/install-gpg.sh
@@ -53,7 +53,7 @@ jobs:
         echo "${MAVEN_HOME}/bin" >> $GITHUB_PATH
 
     - name: Setup Maven repository cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       env:
         cache-name: m2repo
       with:

--- a/maven-version-rules.xml
+++ b/maven-version-rules.xml
@@ -12,7 +12,7 @@
         <!-- Pin logback version to v1.3.x (v1.4.0+ requires Java11) -->
         <rule groupId="ch.qos.logback" comparisonMethod="maven">
             <ignoreVersions>
-                <ignoreVersion type="regex">1\.4\..*</ignoreVersion>
+                <ignoreVersion type="regex">1\.[4-9]\..*</ignoreVersion>
             </ignoreVersions>
         </rule>
         <!-- Pin checkstyle version to pre-v10 (v10 is requires Java11) -->
@@ -25,6 +25,7 @@
         <rule groupId="org.testng" artifactId="testng" comparisonMethod="maven">
             <ignoreVersions>
                 <ignoreVersion type="regex">7\.[6-9].*</ignoreVersion>
+                <ignoreVersion type="regex">7\.10\..*</ignoreVersion>
             </ignoreVersions>
         </rule>
         <!-- Pin git-commit-id-plugin version to final 4.x release version (v5+ requires Java11 -->

--- a/pmd.xml
+++ b/pmd.xml
@@ -11,10 +11,12 @@
     </description>
     <rule ref="category/java/bestpractices.xml/AvoidUsingHardCodedIP"/>
     <rule ref="category/java/bestpractices.xml/CheckResultSet"/>
+    <rule ref="category/java/bestpractices.xml/PrimitiveWrapperInstantiation"/>
     <rule ref="category/java/bestpractices.xml/UnusedFormalParameter"/>
     <rule ref="category/java/bestpractices.xml/UnusedLocalVariable"/>
     <rule ref="category/java/bestpractices.xml/UnusedPrivateField"/>
     <rule ref="category/java/bestpractices.xml/UnusedPrivateMethod"/>
+    <rule ref="category/java/codestyle.xml/EmptyControlStatement"/>
     <rule ref="category/java/codestyle.xml/ExtendsObject"/>
     <rule ref="category/java/codestyle.xml/ForLoopShouldBeWhileLoop"/>
     <rule ref="category/java/codestyle.xml/TooManyStaticImports"/>
@@ -22,6 +24,7 @@
     <rule ref="category/java/codestyle.xml/UnnecessaryImport"/>
     <rule ref="category/java/codestyle.xml/UnnecessaryModifier"/>
     <rule ref="category/java/codestyle.xml/UnnecessaryReturn"/>
+    <rule ref="category/java/codestyle.xml/UnnecessarySemicolon"/>
     <rule ref="category/java/codestyle.xml/UselessParentheses"/>
     <rule ref="category/java/codestyle.xml/UselessQualifiedThis"/>
     <rule ref="category/java/design.xml/CollapsibleIfStatements"/>
@@ -36,15 +39,6 @@
     <rule ref="category/java/errorprone.xml/ClassCastExceptionWithToArray"/>
     <rule ref="category/java/errorprone.xml/DontUseFloatTypeForLoopIndices"/>
     <rule ref="category/java/errorprone.xml/EmptyCatchBlock"/>
-    <rule ref="category/java/errorprone.xml/EmptyFinallyBlock"/>
-    <rule ref="category/java/errorprone.xml/EmptyIfStmt"/>
-    <rule ref="category/java/errorprone.xml/EmptyInitializer"/>
-    <rule ref="category/java/errorprone.xml/EmptyStatementBlock"/>
-    <rule ref="category/java/errorprone.xml/EmptyStatementNotInLoop"/>
-    <rule ref="category/java/errorprone.xml/EmptySwitchStatements"/>
-    <rule ref="category/java/errorprone.xml/EmptySynchronizedBlock"/>
-    <rule ref="category/java/errorprone.xml/EmptyTryBlock"/>
-    <rule ref="category/java/errorprone.xml/EmptyWhileStmt"/>
     <rule ref="category/java/errorprone.xml/JumbledIncrementer"/>
     <rule ref="category/java/errorprone.xml/MisplacedNullCheck"/>
     <rule ref="category/java/errorprone.xml/OverrideBothEqualsAndHashcode"/>
@@ -57,5 +51,4 @@
     <rule ref="category/java/multithreading.xml/DontCallThreadRun"/>
     <rule ref="category/java/multithreading.xml/DoubleCheckedLocking"/>
     <rule ref="category/java/performance.xml/BigIntegerInstantiation"/>
-    <rule ref="category/java/performance.xml/BooleanInstantiation"/>
 </ruleset>

--- a/pom.xml
+++ b/pom.xml
@@ -114,51 +114,51 @@
         <test.db.name>postgis1</test.db.name>
         <test.db.port>5432</test.db.port>
         <!-- Plugin versioning -->
-        <build-helper-maven-plugin.version>3.5.0</build-helper-maven-plugin.version>
+        <build-helper-maven-plugin.version>3.6.0</build-helper-maven-plugin.version>
         <directory-maven-plugin.version>1.0</directory-maven-plugin.version>
-        <download-maven-plugin.version>1.7.1</download-maven-plugin.version>
-        <exec-maven-plugin.version>3.1.1</exec-maven-plugin.version>
+        <download-maven-plugin.version>1.9.0</download-maven-plugin.version>
+        <exec-maven-plugin.version>3.3.0</exec-maven-plugin.version>
         <git-commit-id-plugin.version>4.9.10</git-commit-id-plugin.version>
-        <jacoco-maven-plugin.version>0.8.11</jacoco-maven-plugin.version>
+        <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
         <maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
         <maven-archetype-plugin.version>3.2.1</maven-archetype-plugin.version>
-        <maven-assembly-plugin.version>3.6.0</maven-assembly-plugin.version>
-        <maven-checkstyle-plugin.version>3.3.1</maven-checkstyle-plugin.version>
-        <maven-clean-plugin.version>3.3.2</maven-clean-plugin.version>
-        <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
-        <maven-dependency-plugin.version>3.6.1</maven-dependency-plugin.version>
-        <maven-deploy-plugin.version>3.1.1</maven-deploy-plugin.version>
+        <maven-assembly-plugin.version>3.7.1</maven-assembly-plugin.version>
+        <maven-checkstyle-plugin.version>3.4.0</maven-checkstyle-plugin.version>
+        <maven-clean-plugin.version>3.4.0</maven-clean-plugin.version>
+        <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
+        <maven-dependency-plugin.version>3.7.1</maven-dependency-plugin.version>
+        <maven-deploy-plugin.version>3.1.2</maven-deploy-plugin.version>
         <maven-ear-plugin.version>3.3.0</maven-ear-plugin.version>
         <maven-ejb-plugin.version>3.0.1</maven-ejb-plugin.version>
-        <maven-enforcer-plugin.version>3.4.1</maven-enforcer-plugin.version>
-        <maven-failsafe-plugin.version>3.2.2</maven-failsafe-plugin.version>
-        <maven-gpg-plugin.version>3.1.0</maven-gpg-plugin.version>
-        <maven-install-plugin.version>3.1.1</maven-install-plugin.version>
-        <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
+        <maven-enforcer-plugin.version>3.5.0</maven-enforcer-plugin.version>
+        <maven-failsafe-plugin.version>3.3.1</maven-failsafe-plugin.version>
+        <maven-gpg-plugin.version>3.2.4</maven-gpg-plugin.version>
+        <maven-install-plugin.version>3.1.2</maven-install-plugin.version>
+        <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
         <maven-jarsigner-plugin.version>3.0.0</maven-jarsigner-plugin.version>
-        <maven-javadoc-plugin.version>3.6.3</maven-javadoc-plugin.version>
-        <maven-jxr-plugin.version>3.3.1</maven-jxr-plugin.version>
-        <maven-pmd-plugin.version>3.21.2</maven-pmd-plugin.version>
-        <maven-project-info-reports-plugin.version>3.5.0</maven-project-info-reports-plugin.version>
-        <maven-release-plugin.version>3.0.1</maven-release-plugin.version>
+        <maven-javadoc-plugin.version>3.8.0</maven-javadoc-plugin.version>
+        <maven-jxr-plugin.version>3.4.0</maven-jxr-plugin.version>
+        <maven-pmd-plugin.version>3.24.0</maven-pmd-plugin.version>
+        <maven-project-info-reports-plugin.version>3.6.2</maven-project-info-reports-plugin.version>
+        <maven-release-plugin.version>3.1.1</maven-release-plugin.version>
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
-        <maven-shade-plugin.version>3.5.1</maven-shade-plugin.version>
+        <maven-shade-plugin.version>3.6.0</maven-shade-plugin.version>
         <maven-site-plugin.version>3.12.1</maven-site-plugin.version>
-        <maven-source-plugin.version>3.3.0</maven-source-plugin.version>
-        <maven-surefire-plugin.version>3.2.2</maven-surefire-plugin.version>
-        <maven-surefire-report-plugin.version>3.2.2</maven-surefire-report-plugin.version>
+        <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
+        <maven-surefire-plugin.version>3.3.1</maven-surefire-plugin.version>
+        <maven-surefire-report-plugin.version>3.3.1</maven-surefire-report-plugin.version>
         <maven-war-plugin.version>3.4.0</maven-war-plugin.version>
-        <spotbugs-maven-plugin.version>4.8.2.0</spotbugs-maven-plugin.version>
-        <versions-maven-plugin.version>2.16.2</versions-maven-plugin.version>
+        <spotbugs-maven-plugin.version>4.8.6.2</spotbugs-maven-plugin.version>
+        <versions-maven-plugin.version>2.17.1</versions-maven-plugin.version>
         <!-- Dependency versions -->
         <dependency.checkstyle.version>9.3</dependency.checkstyle.version>
         <dependency.jts-version.version>1.19.0</dependency.jts-version.version>
         <dependency.logback.version>1.3.14</dependency.logback.version>
-        <dependency.pmd.version>6.55.0</dependency.pmd.version>
+        <dependency.pmd.version>7.4.0</dependency.pmd.version>
         <dependency.postgresql-jdbc.version>42.7.1</dependency.postgresql-jdbc.version>
-        <dependency.slf4j.version>2.0.9</dependency.slf4j.version>
+        <dependency.slf4j.version>2.0.13</dependency.slf4j.version>
         <dependency.spatial4j.version>0.8</dependency.spatial4j.version>
-        <dependency.spotbugs.version>4.8.2</dependency.spotbugs.version>
+        <dependency.spotbugs.version>4.8.6</dependency.spotbugs.version>
         <dependency.testcontainers.version>1.19.3</dependency.testcontainers.version>
         <dependency.testng.version>7.5.1</dependency.testng.version>
     </properties>


### PR DESCRIPTION
- CI os updated from ubuntu-22.04 to ubuntu-24.04
- CI java updated from zulu 8.0.392/11.0.21/17.0.9/21.0.1 to 8.0.422/11.0.24/17.0.12/21.0.4
- CI maven updated from v3.9.6 to v3.9.8
- build-helper-maven-plugin updated from v3.5.0 to v3.6.0
- download-maven-plugin updated from v1.7.1 to v1.9.0
- exec-maven-plugin updated from v3.1.1 to v3.3.0
- jacoco-maven-plugin updated from v0.8.11 to v0.8.12
- maven-assembly-plugin updated from v3.6.0 to v3.7.1
- maven-checkstyle-plugin updated from v3.3.1 to v3.4.0
- maven-clean-plugin updated from v3.3.2 to v3.4.0
- maven-compiler-plugin updated from v3.11.0 to v3.13.0
- maven-dependency-plugin updated from v3.6.1 to v3.7.1
- maven-deploy-plugin updated from v3.1.1 to v3.1.2
- maven-enforcer-plugin updated from v3.4.1 to v3.5.0
- maven-failsafe-plugin updated from v3.2.2 to v3.3.1
- maven-gpg-plugin updated from v3.1.0 to v3.2.4
- maven-install-plugin updated from v3.1.0 to v3.1.2
- maven-jar-plugin updated from v3.3.0 to v3.4.2
- maven-javadoc-plugin updated from v3.6.3 to v3.8.0
- maven-jxr-plugin updated from v3.3.1 to v3.4.0
- maven-pmd-plugin updated from v3.21.2 to v3.24.0
- maven-project-info-reports-plugin updated from v3.5.0 to v3.6.2
- maven-release-plugin updated from v3.0.1 to v3.1.1
- maven-shade-plugin updated from v3.5.1 to v3.6.0
- maven-source-plugin updated from v3.3.0 to v3.3.1
- maven-surefire-plugin updated from v3.2.2 to v3.3.1
- maven-surefire-report-plugin updated from v3.2.2 to v3.3.1
- spotbugs-maven-plugin updated from v4.8.2.0 to v4.8.6.2
- versions-maven-plugin updated from v2.16.2 to v2.17.1
- pmd updated from v6.55.0 to v7.4.0
- slf4j updated from v2.0.9 to v2.0.13
- spotbugs updated from v4.8.2 to v4.8.6