### PR TITLE
Build Updates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,16 +11,16 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04]
-        jdk_version: [8.0.442-zulu, 11.0.25-zulu, 17.0.13-zulu, 21.0.5-zulu]
+        jdk_version: [8.0.452-zulu, 11.0.27-zulu, 17.0.15-zulu, 21.0.7-zulu, 24.0.1-zulu]
         include:
           - os: ubuntu-24.04
-            jdk_version: 8.0.442-zulu
-            zulu_version: 8.84.0.15
+            jdk_version: 8.0.452-zulu
+            zulu_version: 8.86.0.25
             maven_deploy: true
             docker_build: true
             maven_docker_container_image_repo: luminositylabs
             maven_docker_container_image_name: openjdk
-            maven_docker_container_image_tag: 8u442_zulu-alpine-8.84.0.15
+            maven_docker_container_image_tag: 8u452_zulu-alpine-8.86.0.25
     name: Build on OS ${{ matrix.os }} using JDK ${{ matrix.jdk_version }}
     runs-on: ${{ matrix.os }}
     env:

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,3 +1,3 @@
 --strict-checksums
 --update-snapshots
--Djavadoc.path=${SDKMAN_DIR}/candidates/java/8.0.442-zulu/bin/javadoc
+-Djavadoc.path=${SDKMAN_DIR}/candidates/java/8.0.452-zulu/bin/javadoc

--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,3 +1,3 @@
 # Enable auto-env through the sdkman_auto_env config
 # Add key=value pairs of SDKs to use below
-java=8.0.442-zulu
+java=8.0.452-zulu

--- a/pom.xml
+++ b/pom.xml
@@ -117,21 +117,21 @@
         <build-helper-maven-plugin.version>3.6.0</build-helper-maven-plugin.version>
         <directory-maven-plugin.version>1.0</directory-maven-plugin.version>
         <download-maven-plugin.version>1.13.0</download-maven-plugin.version>
-        <exec-maven-plugin.version>3.5.0</exec-maven-plugin.version>
+        <exec-maven-plugin.version>3.5.1</exec-maven-plugin.version>
         <git-commit-id-plugin.version>4.9.10</git-commit-id-plugin.version>
-        <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
+        <jacoco-maven-plugin.version>0.8.13</jacoco-maven-plugin.version>
         <maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
-        <maven-archetype-plugin.version>3.3.1</maven-archetype-plugin.version>
+        <maven-archetype-plugin.version>3.4.0</maven-archetype-plugin.version>
         <maven-assembly-plugin.version>3.7.1</maven-assembly-plugin.version>
         <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
-        <maven-clean-plugin.version>3.4.1</maven-clean-plugin.version>
+        <maven-clean-plugin.version>3.5.0</maven-clean-plugin.version>
         <maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>
         <maven-dependency-plugin.version>3.8.1</maven-dependency-plugin.version>
         <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
         <maven-ear-plugin.version>3.3.0</maven-ear-plugin.version>
         <maven-ejb-plugin.version>3.0.1</maven-ejb-plugin.version>
         <maven-enforcer-plugin.version>3.5.0</maven-enforcer-plugin.version>
-        <maven-failsafe-plugin.version>3.5.2</maven-failsafe-plugin.version>
+        <maven-failsafe-plugin.version>3.5.3</maven-failsafe-plugin.version>
         <maven-gpg-plugin.version>3.2.7</maven-gpg-plugin.version>
         <maven-install-plugin.version>3.1.4</maven-install-plugin.version>
         <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
@@ -145,8 +145,8 @@
         <maven-shade-plugin.version>3.6.0</maven-shade-plugin.version>
         <maven-site-plugin.version>3.21.0</maven-site-plugin.version>
         <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
-        <maven-surefire-plugin.version>3.5.2</maven-surefire-plugin.version>
-        <maven-surefire-report-plugin.version>3.5.2</maven-surefire-report-plugin.version>
+        <maven-surefire-plugin.version>3.5.3</maven-surefire-plugin.version>
+        <maven-surefire-report-plugin.version>3.5.3</maven-surefire-report-plugin.version>
         <maven-war-plugin.version>3.4.0</maven-war-plugin.version>
         <maven-wrapper-plugin.version>3.3.2</maven-wrapper-plugin.version>
         <spotbugs-maven-plugin.version>4.8.6.6</spotbugs-maven-plugin.version>
@@ -155,12 +155,12 @@
         <dependency.checkstyle.version>9.3</dependency.checkstyle.version>
         <dependency.jts-version.version>1.20.0</dependency.jts-version.version>
         <dependency.logback.version>1.3.15</dependency.logback.version>
-        <dependency.pmd.version>7.11.0</dependency.pmd.version>
-        <dependency.postgresql-jdbc.version>42.7.5</dependency.postgresql-jdbc.version>
+        <dependency.pmd.version>7.14.0</dependency.pmd.version>
+        <dependency.postgresql-jdbc.version>42.7.6</dependency.postgresql-jdbc.version>
         <dependency.slf4j.version>2.0.17</dependency.slf4j.version>
         <dependency.spatial4j.version>0.8</dependency.spatial4j.version>
         <dependency.spotbugs.version>4.8.6</dependency.spotbugs.version>
-        <dependency.testcontainers.version>1.20.6</dependency.testcontainers.version>
+        <dependency.testcontainers.version>1.21.1</dependency.testcontainers.version>
         <dependency.testng.version>7.5.1</dependency.testng.version>
     </properties>
 


### PR DESCRIPTION
- updated .sdkmanrc java setting from 8.0.442-zulu to 8.0.452-zulu
- updated .mvn/maven.config to reference javadoc path of 8.0.452-zulu
- exec-maven-plugin updated from v3.5.0 to v3.5.1
- jacoco-maven-plugin updated from v0.8.12 to v0.8.13
- maven-archetype-plugin updated from v3.3.1 to v3.4.0
- maven-clean-plugin updated from v3.4.1 to v3.5.0
- maven-failsafe-plugin updated from v3.5.2 to v3.5.3
- maven-surefire-plugin updated from v3.5.2 to v3.5.3
- maven-surefire-report-plugin from v3.5.2 to v3.5.3
- pmd updated from v7.11.0 ro v7.14.0
- postgresql-jdbc updated from v42.7.5 to v42.7.6
- testcontainers updated from v1.20.6 to v1.21.1